### PR TITLE
DebugMessage

### DIFF
--- a/TF2Net/NetMessageCoder.cs
+++ b/TF2Net/NetMessageCoder.cs
@@ -64,8 +64,12 @@ namespace TF2Net
 
 				case NetMessageType.SVC_GAMEEVENTLIST:		return new NetGameEventListMessage();
 
-				default:	throw new NotImplementedException(string.Format("Unimplemented {0} \"{1}\"", typeof(NetMessageType).Name, type));
-			}
-		}
+#if DEBUG
+			    default: return new DebugMessage { Type = type };
+#else
+                default:                                    throw new NotImplementedException(string.Format("Unimplemented {0} \"{1}\"", typeof(NetMessageType).Name, type));
+#endif
+            }
+        }
 	}
 }

--- a/TF2Net/NetMessages/DebugMessage.cs
+++ b/TF2Net/NetMessages/DebugMessage.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using BitSet;
+using TF2Net.Data;
+
+namespace TF2Net.NetMessages
+{
+    class DebugMessage : INetMessage
+    {
+        private static int _messageCount;
+        private static int _maxMessageCount = 1;
+        private readonly IList<bool> _bs = new List<bool>();
+        private readonly IList<Candidate> _candidates = new List<Candidate>();
+        private Candidate _bestCandidate;
+
+
+        public string Description => _bestCandidate?.FieldLength.ToString() ?? "null";
+
+        public NetMessageType Type { get; set; }
+
+
+        public void ReadMsg(BitStream stream)
+        {
+            if (_messageCount + 1 > _maxMessageCount)
+            {
+                Debug.WriteLine("hit MaxMessageCOunt abourting");
+
+                throw new ApplicationException();
+            }
+
+            _messageCount++;
+            while (stream.Length - stream.Cursor > 2)
+            {
+                _bs.Add(stream.ReadBool());
+
+                //removing DebugListeners to ignore Debug.Assert's while trying to parse with current length
+                TraceListener[] listeners = new TraceListener[Debug.Listeners.Count];
+                Debug.Listeners.CopyTo(listeners, 0);
+                Debug.Listeners.Clear();
+
+                try
+                {
+                    List<INetMessage> netMessages = NetMessageCoder.Decode(stream.Clone());
+                    AddCandidates(netMessages);
+                }
+                catch (StackOverflowException)
+                {
+                    Debug.WriteLine("hit StackOverflowException aborting");
+                    break;
+                }
+                catch (OverflowException exception)
+                {
+                    Debug.WriteLine("hit OverflowException aborting");
+                    break;
+                }
+                catch (Exception exception)
+                {
+                }
+                finally
+                {
+                    Debug.Listeners.AddRange(listeners);
+                }
+            }
+
+            _bestCandidate = _candidates
+                .Where(c => c.Messages.Count > 0)
+                .Where(c => c.ChildDebugMessageLength != int.MaxValue)
+                .OrderByDescending(c => c.Messages.Count)
+                .ThenBy(c => c.ChildDebugMessageLength)
+                .FirstOrDefault();
+
+            if (_bestCandidate == null)
+                Debug.WriteLine("Unknown message: no candidate");
+            else
+                Debug.WriteLine("Unknown message: {0} bits long with best candidate having {1} unknown bits ", _bestCandidate.FieldLength, _bestCandidate.ChildDebugMessageLength);
+
+            _messageCount--;
+        }
+
+        private void AddCandidates(List<INetMessage> netMessages)
+        {
+            int childDebugMessageLength = netMessages.Count == 0
+                ? 0
+                : netMessages.Max(m =>
+                {
+                    DebugMessage debugMessage = m as DebugMessage;
+                    if (debugMessage == null)
+                        return 0;
+                    if (debugMessage._bestCandidate == null)
+                        return int.MaxValue;
+                    return debugMessage._bestCandidate.FieldLength;
+                });
+            _candidates.Add(
+                new Candidate
+                {
+                    Messages = netMessages,
+                    FieldLength = _bs.Count,
+                    ChildDebugMessageLength = childDebugMessageLength,
+                });
+        }
+
+        public void ApplyWorldState(WorldState ws)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        private class Candidate
+        {
+            public int FieldLength { get; set; }
+            public List<INetMessage> Messages { get; set; }
+            public int ChildDebugMessageLength { get; set; }
+        }
+    }
+}

--- a/TF2Net/TF2Net.csproj
+++ b/TF2Net/TF2Net.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Monitors\EntityMonitor.cs" />
     <Compile Include="Monitors\EntityPropertyMonitor.cs" />
     <Compile Include="Monitors\MultiPropertyMonitor.cs" />
+    <Compile Include="NetMessages\DebugMessage.cs" />
     <Compile Include="NetMessages\Shared\EntityCoder.cs" />
     <Compile Include="SingleEvent.cs" />
     <Compile Include="Data\BaselineIndex.cs" />


### PR DESCRIPTION
When in DEBUG this message is used when a unknown NetMessageType is encountered. The DebugMessage first assumes it has a length of 1 and tries to parse the rest of the stream. Increasing the size and restarting the parse whenever it encouters an error. If the remaining stream can be parsed successfully we Debug.Write that size for further investigation.

**not really tested just used it for the unknown NetMessageType 34 (PazerOP/DemoLib/pull/3)**
_could maybe figure out the length of multiple unkown messages but i have it set up so it restarts when it finds the second unknown message (to try an other size). Also never tested this!_ 

